### PR TITLE
Add two missing dependencies to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,8 @@ RUN \
        mesa-utils \
        libnvidia-gl-460 \
        ttf-mscorefonts-installer \
+       libgtk-3-0 \
+       libwebkit2gtk-4.0-37 \
     && apt-get clean
 
 # User/group

--- a/run
+++ b/run
@@ -2,6 +2,9 @@
 [ -z "${CIQ_SDK_VERSION}" ] && echo 'ERROR: Missing CIQ_SDK_VERSION environment variable' && exit 1
 [ -z "${CIQ_SDK_DIR}" ] && CIQ_SDK_DIR="${HOME}/.Garmin/ConnectIQ"
 [ -z "${XAUTHORITY}" ] && XAUTHORITY="${HOME}/.Xauthority"
+
+[ ! -d "$CIQ_SDK_DIR" ] && mkdir -p "$CIQ_SDK_DIR";
+
 exec docker run \
   --name=connectiq-sdk \
   --privileged \


### PR DESCRIPTION
Running sdkmanager within the container fails when libgtk-3-0 and
libwebkit2gtk-4.0-37 are not installed.

Signed-off-by: Wesley Schwengle <wesley@opperschaap.net>